### PR TITLE
[Feature] Multiple trigger types

### DIFF
--- a/src/structs/SScenario.sol
+++ b/src/structs/SScenario.sol
@@ -4,7 +4,13 @@ pragma solidity ^0.8.21;
 import {SourceData} from "./SSourceData.sol";
 import {ActionData} from "./SActionData.sol";
 
+enum TriggerType {
+    ALL,
+    ANY
+}
+
 struct Script {
+    TriggerType trigger_type;
     SourceData[] sources_to_verify;
     ActionData[] actions_chain;
 }

--- a/src/utils/Errors.sol
+++ b/src/utils/Errors.sol
@@ -18,3 +18,4 @@ error InvalidActionExecutor(address value);
 
 error SourceValidationError(address value);
 error ActionExecutionError(address value);
+error NoValidSources();

--- a/test/utils/CoreLibrary.sol
+++ b/test/utils/CoreLibrary.sol
@@ -10,7 +10,7 @@ import {Core} from "src/Core.sol";
 
 import {RegisterType} from "src/enums/ERegisterType.sol";
 
-import {Script, Scenario, ScenarioWrapper} from "src/structs/SScenario.sol";
+import {Script, Scenario, ScenarioWrapper, TriggerType} from "src/structs/SScenario.sol";
 import {SourceData} from "src/structs/SSourceData.sol";
 import {ActionData} from "src/structs/SActionData.sol";
 
@@ -72,7 +72,8 @@ library CoreLibrary {
         IERC20 token,
         address owner,
         SourceData[] memory sources,
-        ActionData[] memory actions
+        ActionData[] memory actions,
+        TriggerType trigger_type
     ) external returns (uint64 id) {
         // Set up variables for the test scenario.
         uint256 defaultAmount = 1_000_000;
@@ -88,6 +89,7 @@ library CoreLibrary {
 
         // Create a script for the scenario.
         Script[] memory scripts = new Script[](1);
+        scripts[0].trigger_type = trigger_type;
         scripts[0].sources_to_verify = sources;
         scripts[0].actions_chain = actions;
 


### PR DESCRIPTION
# Multiple trigger types feature

This merge request introduces a significant enhancement to the existing codebase by adding support for two distinct trigger types during scenario execution: "ALL" and "ANY." These triggers offer enhanced flexibility and control over how scenarios are processed, allowing for more sophisticated and versatile contract behavior.

**Two new trigger types**, "ALL" and "ANY," have been incorporated into the scenario execution logic. These triggers dictate the conditions under which a scenario can be successfully executed.

- "ALL" trigger type: With this trigger, the contract ensures that all specified sources within a scenario must be confirmed as valid. If any of the sources fail validation, the contract will raise an error and prevent the scenario's execution.

- "ANY" trigger type: In contrast, the "ANY" trigger mandates that at least one source within a scenario must be verified as valid for the entire scenario execution to proceed. This trigger type introduces a more permissive approach, allowing for execution even if only a single source is validated.