### PR TITLE
[Feature] Indexing parameter

### DIFF
--- a/src/Core.sol
+++ b/src/Core.sol
@@ -195,8 +195,9 @@ contract Core is ICore, Context, ReentrancyGuard {
     /**
      * @notice Adds a new scenario.
      * @param scenario The data of the scenario to be added.
+     * @param index_id An identifier associated with the scenario (for off-chain matching purposes).
      */
-    function addScenario(Scenario calldata scenario) external returns (uint64 id) {
+    function addScenario(Scenario calldata scenario, uint64 index_id) external returns (uint64 id) {
         // Check if the actor address is valid (not equal to address(0)).
         if (scenario.actor == address(0)) {
             revert InvalidActorAddress();
@@ -267,7 +268,7 @@ contract Core is ICore, Context, ReentrancyGuard {
         s_list[_msgSender()].insert(id);
 
         // Emit an event to indicate successful addition of the scenario.
-        emit ScenarioAdded(_msgSender(), id);
+        emit ScenarioAdded(_msgSender(), id, scenario.input_amount, index_id);
     }
 
     /**

--- a/src/interfaces/ICore.sol
+++ b/src/interfaces/ICore.sol
@@ -8,7 +8,7 @@ interface ICore {
     event RegisterUpdated(RegisterType indexed t, address indexed addr, bool indexed value);
     event ExecutionStateUpdated(bool _old, bool indexed _new);
 
-    event ScenarioAdded(address indexed, uint64 indexed);
+    event ScenarioAdded(address indexed, uint64 indexed, uint256 indexed, uint64);
     event ScenarioRemoved(address indexed, uint64 indexed);
     event ScenarioExecuted(address indexed, uint64 indexed);
 
@@ -26,7 +26,7 @@ interface ICore {
     function getScenariosIdsByOwner(address) external view returns (uint64[] memory);
 
     // Scenario write methods.
-    function addScenario(Scenario calldata) external returns (uint64);
+    function addScenario(Scenario calldata, uint64) external returns (uint64);
     function removeScenario(uint64) external;
     function executeScenario(address, uint64, uint8) external;
 }

--- a/test/Core.t.sol
+++ b/test/Core.t.sol
@@ -171,7 +171,7 @@ contract CoreTest is Test {
         });
 
         // Add the scenario to the Core contract.
-        core.addScenario(scenario);
+        core.addScenario(scenario, 0);
 
         // Stop the sender address simulation.
         vm.stopPrank();
@@ -198,7 +198,7 @@ contract CoreTest is Test {
         vm.expectRevert(InvalidActorAddress.selector);
 
         // Try to add the scenario.
-        core.addScenario(scenario);
+        core.addScenario(scenario, 0);
     }
 
     // Function to test adding a scenario with an invalid input token address.
@@ -217,7 +217,7 @@ contract CoreTest is Test {
         vm.expectRevert(InvalidInputTokenAddress.selector);
 
         // Try to add the scenario.
-        core.addScenario(scenario);
+        core.addScenario(scenario, 0);
     }
 
     // Function to test adding a scenario with an invalid input amount.
@@ -236,7 +236,7 @@ contract CoreTest is Test {
         vm.expectRevert(InvalidInputAmount.selector);
 
         // Try to add the scenario.
-        core.addScenario(scenario);
+        core.addScenario(scenario, 0);
     }
 
     // Function to test adding a scenario with an invalid source address.
@@ -258,7 +258,7 @@ contract CoreTest is Test {
         vm.expectRevert(abi.encodeWithSelector(InvalidSource.selector, address(0)));
 
         // Try to add the scenario.
-        core.addScenario(scenario);
+        core.addScenario(scenario, 0);
     }
 
     // Function to test adding a scenario with an invalid action executor address.
@@ -280,7 +280,7 @@ contract CoreTest is Test {
         vm.expectRevert(abi.encodeWithSelector(InvalidActionExecutor.selector, address(0)));
 
         // Add the scenario to the Core contract (should revert due to invalid action executor address).
-        core.addScenario(scenario);
+        core.addScenario(scenario, 0);
     }
 
     // Function to test unauthorized removal of a scenario.

--- a/test/utils/CoreLibrary.sol
+++ b/test/utils/CoreLibrary.sol
@@ -56,7 +56,7 @@ library CoreLibrary {
         });
 
         // Add the scenario to the Core contract.
-        id = core.addScenario(scenario);
+        id = core.addScenario(scenario, 0);
 
         // Stop the sender address simulation.
         Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D).stopPrank();
@@ -102,7 +102,7 @@ library CoreLibrary {
         });
 
         // Add the scenario to the Core contract.
-        id = core.addScenario(scenario);
+        id = core.addScenario(scenario, 0);
 
         // Stop the sender address simulation.
         Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D).stopPrank();


### PR DESCRIPTION
# Indexing parameter

Previously, tracking and matching on-chain scenarios with their off-chain counterparts was challenging due to the lack of a direct association between the two. This issue could potentially result in incorrect data updates and overwrite off-chain scenarios unintentionally.

With the addition of the `index_id` parameter to the `ScenarioAdded` event, we provide a unique identifier for each on-chain scenario. This identifier serves as a link between on-chain and off-chain scenarios, enabling our `Observer` system to accurately synchronise data between the blockchain and the off-chain database.