### PR TITLE
[Feature] Numeric source condition data type

### DIFF
--- a/src/interfaces/ISource.sol
+++ b/src/interfaces/ISource.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.21;
 
 struct SourceCall {
     uint8 kind;
+    uint8 condition;
     bytes input;
-    bytes condition;
 }
 
 interface ISource {

--- a/src/structs/SSourceData.sol
+++ b/src/structs/SSourceData.sol
@@ -4,6 +4,6 @@ pragma solidity ^0.8.21;
 struct SourceData {
     address addr;
     uint8 kind;
+    uint8 condition;
     bytes input;
-    bytes condition;
 }

--- a/test/Core.t.sol
+++ b/test/Core.t.sol
@@ -244,7 +244,7 @@ contract CoreTest is Test {
         // Create a script for the scenario with an invalid source address (address(0)).
         Script[] memory scripts = new Script[](1);
         scripts[0].sources_to_verify = new SourceData[](1);
-        scripts[0].sources_to_verify[0] = SourceData({addr: address(0), kind: 0, input: "", condition: ""});
+        scripts[0].sources_to_verify[0] = SourceData({addr: address(0), kind: 0, input: "", condition: 0});
 
         Scenario memory scenario = Scenario({
             owner: address(this),
@@ -356,7 +356,7 @@ contract CoreTest is Test {
             addr: address(dexsource),
             kind: 1, // Invalid Kind
             input: "",
-            condition: ""
+            condition: 0
         });
 
         ActionData[] memory actions = new ActionData[](1);
@@ -381,7 +381,7 @@ contract CoreTest is Test {
             addr: address(dexsource),
             kind: 1, // Invalid Kind
             input: "",
-            condition: ""
+            condition: 0
         });
 
         ActionData[] memory actions = new ActionData[](1);
@@ -402,7 +402,7 @@ contract CoreTest is Test {
     function testExecutionRevertExecuteScenario() external {
         // Create an invalid scenario with an invalid action executor input (empty data).
         SourceData[] memory sources = new SourceData[](1);
-        sources[0] = SourceData({addr: address(dexsource), kind: 0, input: "", condition: ""});
+        sources[0] = SourceData({addr: address(dexsource), kind: 0, input: "", condition: 0});
 
         ActionData[] memory actions = new ActionData[](1);
         actions[0] = ActionData({executor: address(transferExecutor), input: ""});
@@ -422,7 +422,7 @@ contract CoreTest is Test {
     function testInvalidFinalOutputExecuteScenario() external {
         // Create an invalid scenario with an executor that does nothing.
         SourceData[] memory sources = new SourceData[](1);
-        sources[0] = SourceData({addr: address(dexsource), kind: 0, input: "", condition: ""});
+        sources[0] = SourceData({addr: address(dexsource), kind: 0, input: "", condition: 0});
 
         ActionData[] memory actions = new ActionData[](1);
         actions[0] = ActionData({executor: address(nothingExecutor), input: ""});
@@ -442,7 +442,7 @@ contract CoreTest is Test {
     function testExecuteScenario() external {
         // Create a valid scenario with a transfer action to address(3).
         SourceData[] memory sources = new SourceData[](1);
-        sources[0] = SourceData({addr: address(dexsource), kind: 0, input: "", condition: ""});
+        sources[0] = SourceData({addr: address(dexsource), kind: 0, input: "", condition: 0});
 
         ActionData[] memory actions = new ActionData[](1);
         actions[0] = ActionData({executor: address(transferExecutor), input: abi.encode(address(3))});


### PR DESCRIPTION
Now the `condition` field of data structures associated with the `Source` has a numeric form (`uint8` type), instead of a `bytes` type.